### PR TITLE
fix recurring rule to not recurring tasks and end-date is not obrigatory

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -23,9 +23,14 @@ class TasksController < ApplicationController
     @task = Task.new(task_params)
     authorize @task
     if @task.save
-      if params[:task][:schedule_attributes][:recurring_rule] != ""
-        schedule = @task.schedule
+      schedule = @task.schedule
+      raise
+      schedule.end_time = schedule.start_time + 1.years if schedule.end_time.nil?
+      if params[:task][:schedule_attributes][:recurring_rule] != "null"
         schedule.recurring_rule = params[:task][:schedule_attributes][:recurring_rule]
+        schedule.save
+      else
+        schedule.recurring_rule = IceCube::Rule.daily.count(1)
         schedule.save
       end
       redirect_to main_page_path, notice: "A tarefa foi criada com sucesso!"

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -4,7 +4,7 @@ class Schedule < ApplicationRecord
   belongs_to :user
   has_many :schedule_exceptions, dependent: :destroy
 
-  validates :start_time, :end_time, :due_time, :pet_id, :user_id, presence: true
+  validates :start_time, :due_time, :pet_id, :user_id, presence: true
 
   serialize :recurring_rule, Hash
   def recurring_rule=(value)


### PR DESCRIPTION
when the user dont give a frequency, add a frequency that repeats only once (that solve some bugs).
end_time not obrigatory to the user to input, but we manually tell that it is start_time +1 year